### PR TITLE
Inject License Key (temporarily); Update S3 Target

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,12 +3,6 @@ set -x
 
 if [ -z $1 ]; then
   echo "MUST PASS BUILDER, virtualbox-ovf or vmware-vmx! Exiting..."
-  exit 2
-fi
-
-
-if [ "${PRIV_KEY}" == ''] || [ "${PUB_KEY}" == '' ]; then
-  echo "MUST SET PRIV_KEY and PUB_KEY, exiting..."
   exit 1
 fi
 
@@ -21,8 +15,7 @@ else
   export GIT_VERSION=$GIT_TAG
 fi
 
-PRIV_KEY="${PRIV_KEY}"
-PUB_KEY="${PUB_KEY}"
+LIC_KEY="${LIC_KEY}"
 DOWNLOAD_VERSION=${DOWNLOAD_VERSION:-2017.2.2}
 DOWNLOAD_DIST=${DOWNLOAD_DIST:-el}
 DOWNLOAD_RELEASE=${DOWNLOAD_RELEASE:-7}
@@ -109,8 +102,7 @@ packer build \
   -parallel=false \
   -var "GIT_VERSION=$GIT_VERSION" \
   -var "GIT_REMOTE=$GIT_REMOTE" \
-  -var "PRIV_KEY=$PRIV_KEY" \
-  -var "PUB_KEY=$PUB_KEY" \
+  -var "LIC_KEY=$LIC_KEY" \
   -var "BUILD_VER=$BUILD_VER" \
   -var "DOWNLOAD_VERSION=$DOWNLOAD_VERSION" \
   -var "DOWNLOAD_DIST=$DOWNLOAD_DIST" \

--- a/centos72.json
+++ b/centos72.json
@@ -48,8 +48,7 @@
       ],
       "environment_vars": [
         "GIT_REMOTE={{ user `GIT_REMOTE`}}",
-        "PRIV_KEY={{ user `PRIV_KEY`}}",
-        "PUB_KEY={{ user `PUB_KEY`}}",
+        "LIC_KEY={{ user `LIC_KEY`}}",
         "DOWNLOAD_VERSION={{ user `DOWNLOAD_VERSION` }}",
         "DOWNLOAD_DIST={{ user `DOWNLOAD_DIST` }}",
         "DOWNLOAD_RELEASE={{ user `DOWNLOAD_RELEASE` }}",


### PR DESCRIPTION
Prior to this commit we relied on using SSH keys for Puppetserver to
access PE only modules.  This commit moves to using a license key that
is put in place only during build time.  Additionally, there is now a
new S3 bucket subfolder, called branches, where all artifacts that are
built from non-master branch.