### PR TITLE
Require Control-Repo Version; Correct Publish Options; Send Notifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -218,7 +218,7 @@ stage("Build and Test"){
                 // Move Archive
                 sh "find . -name \"*.box\" -o -name \"*.ova\" | xargs -I {} mv {} ${target}/"
 
-                if (config['publish_images'] != false) {
+                if (config['publish_images'] == 1) {
 
                   if (config['builds'][index] == 'virtualbox') {
                     sh("""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ stage("Setup") {
     config['vmware_datastore'] = env.VMWARE_DATASTORE
     config['vmware_network'] = env.VMWARE_NETWORK
     config['publish_images'] = env.PUBLISH_IMAGES.toBoolean() == true ? 1 : 0
+    config['build_version'] = env.BUILD_VERSION
     config['ga_release'] = env.GA_RELEASE.toBoolean() == true ? 1 : 0
     config['pe_release'] = env.DIST_RELEASE.toInteger()
     config['git_remote'] = env.GIT_REMOTE
@@ -29,10 +30,10 @@ stage("Setup") {
     config['pe_arch']    = env.PE_ARCH
     config['builds']     = env.BUILDS.split(',')
 
-
     // Determine if this is a tagged version, or just a commit (this gets read from the control-repo)
     dir ('control-repo') {
       git branch: 'production', changelog: false, poll: false, url: env.GIT_REMOTE
+      sh("git reset --hard ${config['build_version']}")
       def gitTag =  sh(returnStdout: true, script: 'git describe --exact-match --tags HEAD 2>/dev/null || exit 0').trim()
       def gitVersion = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
       gitCurrent = gitTag != '' ? gitTag : gitVersion

--- a/centos72.json
+++ b/centos72.json
@@ -47,6 +47,7 @@
         "scripts/setup.sh"
       ],
       "environment_vars": [
+        "BUILD_VER={{ user `BUILD_VER`}}",
         "GIT_REMOTE={{ user `GIT_REMOTE`}}",
         "LIC_KEY={{ user `LIC_KEY`}}",
         "DOWNLOAD_VERSION={{ user `DOWNLOAD_VERSION` }}",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -183,14 +183,19 @@ FILE
     exit 6
   fi
 
-  # Prune non-production branches
-  echo "Pruning branches...."
+  # Reset hard back to our build version
+  echo "Resetting to build version..."
   mkdir ~/.ssh
   chmod 700 ~/.ssh
   ssh-keyscan localhost > ~/.ssh/known_hosts
   echo -e "Host localhost\n\tIdentityFile /etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa" > ~/.ssh/config
   git clone git@localhost:puppet/control-repo.git control-repo
   cd control-repo
+  git reset --hard $BUILD_VER
+  git push origin production -f
+
+  # Prune non-production branches
+  echo "Pruning branches...."
 
   for i in $(git branch -a|grep -v production|awk -F '/' '{print $3}')
   do


### PR DESCRIPTION
- Control-Repo version is now required; this allows a hard-reset to be done to ensure correct version makes it into image
- Publish image options weren't respected
- Notification is now sent for successful build AND that are built using the master (stable) branch of tse-master-builder