### PR TITLE
Shrink Resulting Image Size

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -292,6 +292,57 @@ function cleanup {
   fi
 }
 
+function free_disk_space {
+  # Adopting from https://github.com/boxcutter/centos/blob/master/script/cleanup.sh
+  DISK_USAGE_BEFORE_CLEANUP=$(df -h)
+
+  echo "==> Clean up yum cache of metadata and packages to save space"
+  yum -y --enablerepo='*' clean all
+
+  echo "==> Removing temporary files used to build box"
+  rm -rf /tmp/*
+
+  echo "==> Rebuild RPM DB"
+  rpmdb --rebuilddb
+  rm -f /var/lib/rpm/__db*
+
+  # delete any logs that have built up during the install
+  find /var/log/ -name *.log -exec rm -f {} \;
+
+  echo '==> Clear out swap and disable until reboot'
+  set +e
+  swapuuid=$(/sbin/blkid -o value -l -s UUID -t TYPE=swap)
+  case "$?" in
+    2|0) ;;
+    *) exit 1 ;;
+  esac
+  set -e
+  if [ "x${swapuuid}" != "x" ]; then
+      # Whiteout the swap partition to reduce box size
+      # Swap is disabled till reboot
+      swappart=$(readlink -f /dev/disk/by-uuid/$swapuuid)
+      /sbin/swapoff "${swappart}"
+      dd if=/dev/zero of="${swappart}" bs=1M || echo "dd exit code $? is suppressed"
+      /sbin/mkswap -U "${swapuuid}" "${swappart}"
+  fi
+
+  echo '==> Zeroing out empty area to save space in the final image'
+  # Zero out the free space to save space in the final image.  Contiguous
+  # zeroed space compresses down to nothing.
+  dd if=/dev/zero of=/EMPTY bs=1M || echo "dd exit code $? is suppressed"
+  rm -f /EMPTY
+
+  # Block until the empty file has been removed, otherwise, Packer
+  # will try to kill the box while the disk is still full and that's bad
+  sync
+
+  echo "==> Disk usage before cleanup"
+  echo "${DISK_USAGE_BEFORE_CLEANUP}"
+
+  echo "==> Disk usage after cleanup"
+  df -h
+}
+
 
 # Main
 setup_prereqs
@@ -316,5 +367,6 @@ run_puppet
 run_puppet
 add_gogs_webhook
 cleanup
+free_disk_space
 
 exit 0


### PR DESCRIPTION
Prior to this commit our cleanup process didn't remove a lot of free space resulting in inflated image sizes.  This commit adopts a cleanup process from the the boxcutter project (linked in source) that reduced the image sizes by almost 1G.   