### PR TITLE
Update role for this all-in-one SETeam master

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -61,7 +61,7 @@ function install_pe {
   echo "${LIC_KEY}" > /etc/puppetlabs/license.key
   cat > /etc/puppetlabs/puppet/csr_attributes.yaml << YAML
   extension_requests:
-      pp_role:  master_server
+      pp_role:  seteam_puppet_master
 YAML
   cat > /tmp/pe.conf << FILE
 "console_admin_password": "puppetlabs"


### PR DESCRIPTION
The role name in the control-repo for this server has changed, to
accomodate an additional role. The old name became ambiguous and so a
new name was selected for clarity. The old name continued to work
temporarily.

This commit updates the tse-master-builder code to use the new role
name, so that the old role name can be removed from the control-repo.

**Depends on:** puppetlabs-seteam/control-repo#78