### PR TITLE
Disable vagrant/ssh setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -392,7 +392,7 @@ setup_users
 generate_keys
 
 if [ "$PACKER_BUILDER_TYPE" = "virtualbox-ovf" ]; then
-  vagrant_setup
+#  vagrant_setup
   guest_additions
 fi
 


### PR DESCRIPTION
Suggest omitting vagrant/ssh setup because this image is used in aws/cloud environments now.